### PR TITLE
AD variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ data "oci_core_images" "_" {
 resource "oci_core_instance" "_" {
   for_each            = local.nodes
   display_name        = each.value.node_name
-  availability_domain = data.oci_identity_availability_domains._.availability_domains[0].name
+  availability_domain = data.oci_identity_availability_domains._.availability_domains[var.availability_domain].name
   compartment_id      = local.compartment_id
   shape               = var.shape
   shape_config {

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,11 @@ variable "how_many_nodes" {
   default = 4
 }
 
+variable "availability_domain" {
+  type    = number
+  default = 0
+}
+
 variable "ocpus_per_node" {
   type    = number
   default = 1


### PR DESCRIPTION
Added variable to customize AD since we could have not enough resources in particular AD.

Example of error message while using AD-1 (as default):

 Error: 500-InternalError
│ Provider version: 4.57.0, released on 2021-12-15. This provider is 5 version(s) old.
│ Service: Core Instance
**│ Error Message: Out of host capacity.**
