### PR TITLE
removing the apt-transport-https

### DIFF
--- a/cloudinit.tf
+++ b/cloudinit.tf
@@ -1,6 +1,5 @@
 locals {
   packages = [
-    "apt-transport-https",
     "build-essential",
     "ca-certificates",
     "curl",


### PR DESCRIPTION
**Need to remove the apt-transport-https package to solve the problem to active the kubernetes cluster**

This PR solves the issue *[Unable to connect to the server](https://github.com/jpetazzo/ampernetacle/issues/31)*  . 

Connecting to the dserver i see problems when we try to install the kubelet and kubeadm.  

The problem occurred at this point.
I did several tests changing the cloudnit configs and I always hit the problem of installing the kubelet and kubeadm packages.
The conclusion in all tests was that the apt-transport-https package was the key issue.
Researching I found that apt in the latest versions already has https support. As the apt-transport-https package removes apt I thought of removing the line from cloudinit.tf

And apparently the problem was solved because my cluster went up without problems.