### PR TITLE
Solving the problem to create the Kubernetes Cluster

### DIFF
--- a/cloudinit.tf
+++ b/cloudinit.tf
@@ -34,7 +34,7 @@ data "cloudinit_config" "_" {
       apt:
         sources:
           kubernetes.list:
-            source: "deb https://apt.kubernetes.io/ kubernetes-xenial main"
+            source: "deb https://packages.cloud.google.com/apt/ kubernetes-xenial main"
             key: |
               ${indent(8, data.http.apt_repo_key.body)}
       users:


### PR DESCRIPTION
**Need to remove the change the address of apt repository  to solve the problem to active the kubernetes cluster**

This PR solves the issue https://github.com/jpetazzo/ampernetacle/issues/31 .

Connecting to the server i see problems when we try to install the kubelet and kubeadm.

The problem occurred at this point.
I did several tests changing the cloudnit configs and I always hit the problem of installing the kubelet and kubeadm packages.
The conclusion in all tests was that the apt-transport-https package was the key issue.
Researching I found that apt in the latest versions already has https support. As the apt-transport-https package removes apt I thought of removing the line from cloudinit.tf

But after many test i see an problem here *ttps://apt.kubernetes.io/* . This address has many problems to redirect the traffic to *https://packages.cloud.google.com/apt/* . 

I need to change the kubernetes.list file to 

**"deb https://packages.cloud.google.com/apt/ kubernetes-xenial main"**
