### PR TITLE
Update providers.tf

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     oci = {
-      source  = "hashicorp/oci"
-      version = "4.62.0"
+      source  = "oracle/oci"
+      version = "4.76.0"
     }
   }
 }


### PR DESCRIPTION
Hashicorp replace provider hashicorp/oci to oracle/oci and current version is 4.76.0 