### PR TITLE
[Fix] Weave install URL DNS not resolvable

### DIFF
--- a/cloudinit.tf
+++ b/cloudinit.tf
@@ -114,8 +114,7 @@ data "cloudinit_config" "_" {
         sed -i s/@@PUBLIC_IP_ADDRESS@@/$PUBLIC_IP_ADDRESS/ /etc/kubeadm_config.yaml
         kubeadm init --config=/etc/kubeadm_config.yaml --ignore-preflight-errors=NumCPU
         export KUBECONFIG=/etc/kubernetes/admin.conf
-        kubever=$(kubectl version | base64 | tr -d '\n')
-        kubectl apply -f https://cloud.weave.works/k8s/net?k8s-version=$kubever
+        kubectl apply -f https://github.com/weaveworks/weave/releases/download/${var.weave_version}/weave-daemonset-k8s.yaml
         mkdir -p /home/k8s/.kube
         cp $KUBECONFIG /home/k8s/.kube/config
         chown -R k8s:k8s /home/k8s/.kube

--- a/variables.tf
+++ b/variables.tf
@@ -36,3 +36,8 @@ variable "memory_in_gbs_per_node" {
   type    = number
   default = 6
 }
+
+variable "weave_version" {
+  type = string
+  default = "v2.8.1"
+}


### PR DESCRIPTION
Terraform finish without error but all nodes stay in `NotReady` state.

My troubleshoot seems to show that CNI is not ready.

```bash
root@node1:/# journalctl -u kubelet --since "1 minute ago"
...
node1 kubelet[11142]: E1115 21:23:07.517783   11142 kubelet.go:2373] "Container runtime network not ready" networkReady="NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: cni plugin not initialized`

root@node1:/# journalctl -u containerd |grep cni
Nov 14 23:04:34 node1 containerd[3168]: time="2022-11-14T23:04:34.426039837Z" level=info msg="Start cri plugin with config {PluginConfig:{ContainerdConfig:{Snapshotter:overlayfs DefaultRuntimeName:runc DefaultRuntime:{Type: Engine: PodAnnotations:[] ContainerAnnotations:[] Root: Options:map[] PrivilegedWithoutHostDevices:false BaseRuntimeSpec:} UntrustedWorkloadRuntime:{Type: Engine: PodAnnotations:[] ContainerAnnotations:[] Root: Options:map[] PrivilegedWithoutHostDevices:false BaseRuntimeSpec:} Runtimes:map[runc:{Type:io.containerd.runc.v2 Engine: PodAnnotations:[] ContainerAnnotations:[] Root: Options:map[BinaryName: CriuImagePath: CriuPath: CriuWorkPath: IoGid:0 IoUid:0 NoNewKeyring:false NoPivotRoot:false Root: ShimCgroup: SystemdCgroup:false] PrivilegedWithoutHostDevices:false BaseRuntimeSpec:}] NoPivot:false DisableSnapshotAnnotations:true DiscardUnpackedLayers:false} CniConfig:{NetworkPluginBinDir:/opt/cni/bin NetworkPluginConfDir:/etc/cni/net.d NetworkPluginMaxConfNum:1 NetworkPluginConfTemplate:} Registry:{ConfigPath: Mirrors:map[] Configs:map[] Auths:map[] Headers:map[]} ImageDecryption:{KeyModel:node} DisableTCPService:true StreamServerAddress:127.0.0.1 StreamServerPort:0 StreamIdleTimeout:4h0m0s EnableSelinux:false SelinuxCategoryRange:1024 SandboxImage:k8s.gcr.io/pause:3.5 StatsCollectPeriod:10 SystemdCgroup:false EnableTLSStreaming:false X509KeyPairStreaming:{TLSCertFile: TLSKeyFile:} MaxContainerLogLineSize:16384 DisableCgroup:false DisableApparmor:false RestrictOOMScoreAdj:false MaxConcurrentDownloads:3 DisableProcMount:false UnsetSeccompProfile: TolerateMissingHugetlbController:true DisableHugetlbController:true IgnoreImageDefinedVolumes:false NetNSMountsUnderStateDir:false} ContainerdRootDir:/var/lib/containerd ContainerdEndpoint:/run/containerd/containerd.sock RootDir:/var/lib/containerd/io.containerd.grpc.v1.cri StateDir:/run/containerd/io.containerd.grpc.v1.cri}"
...
Nov 14 23:04:34 node1 containerd[3168]: time="2022-11-14T23:04:34.433725050Z" level=error msg="failed to load cni during init, please check CRI plugin status before setting up network for pods" error="cni config load failed: no network config found in /etc/cni/net.d: cni plugin not initialized: failed to load cni config"
Nov 14 23:04:34 node1 containerd[3168]: time="2022-11-14T23:04:34.519352166Z" level=info msg="Start cni network conf syncer"
```

And /etc/cni/net.d does not contains file. I don't know what should create it, I supposed it was weave installation in https://github.com/jpetazzo/ampernetacle/blob/12616e34a4685310ba999a83f0b3cd5cc6151093/cloudinit.tf#L118
but the address seems to not be valid, a nslookup of `cloud.weave.works` returns a `No answer` message even online.

Applying the installation from weave docs unblocked my issue after several minutes:
```
root@node1:/#  kubectl --kubeconfig=/etc/kubernetes/admin.conf  apply -f https://github.com/weaveworks/weave/releases/download/v2.8.1/weave-daemonset-k8s.yaml
serviceaccount/weave-net created
clusterrole.rbac.authorization.k8s.io/weave-net created
clusterrolebinding.rbac.authorization.k8s.io/weave-net created
role.rbac.authorization.k8s.io/weave-net created
rolebinding.rbac.authorization.k8s.io/weave-net created
daemonset.apps/weave-net created
root@node1:/var/log# kubectl  --kubeconfig=/etc/kubernetes/admin.conf  get node
NAME    STATUS   ROLES           AGE   VERSION
node1   Ready    control-plane   22h   v1.25.4
node2   Ready    <none>          22h   v1.25.4
node3   Ready    <none>          22h   v1.25.4
root@node1:/var/log# ls /etc/cni/net.d/
10-weave.conflist
```

This PR should fix #44 