### PR TITLE
Fix incomplete kubeconfig

### DIFF
--- a/cloudinit.tf
+++ b/cloudinit.tf
@@ -114,8 +114,7 @@ data "cloudinit_config" "_" {
         sed -i s/@@PUBLIC_IP_ADDRESS@@/$PUBLIC_IP_ADDRESS/ /etc/kubeadm_config.yaml
         kubeadm init --config=/etc/kubeadm_config.yaml --ignore-preflight-errors=NumCPU
         export KUBECONFIG=/etc/kubernetes/admin.conf
-        kubever=$(kubectl version | base64 | tr -d '\n')
-        kubectl apply -f https://cloud.weave.works/k8s/net?k8s-version=$kubever
+        kubectl apply -f https://github.com/weaveworks/weave/releases/download/${var.weave_version}/weave-daemonset-k8s.yaml
         mkdir -p /home/k8s/.kube
         cp $KUBECONFIG /home/k8s/.kube/config
         chown -R k8s:k8s /home/k8s/.kube

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "ssh-with-k8s-user" {
   value = format(
-    "\nssh -o StrictHostKeyChecking=no -i %s -l %s %s\n",
+    "\nssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i %s -l %s %s\n",
     local_file.ssh_private_key.filename,
     "k8s",
     oci_core_instance._[1].public_ip
@@ -12,7 +12,7 @@ output "ssh-with-ubuntu-user" {
     "\n",
     [for i in oci_core_instance._ :
       format(
-        "ssh -o StrictHostKeyChecking=no -l ubuntu -p 22 -i %s %s # %s",
+        "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -l ubuntu -p 22 -i %s %s # %s",
         local_file.ssh_private_key.filename,
         i.public_ip,
         i.display_name

--- a/variables.tf
+++ b/variables.tf
@@ -36,3 +36,8 @@ variable "memory_in_gbs_per_node" {
   type    = number
   default = 6
 }
+
+variable "weave_version" {
+  type = string
+  default = "v2.8.1"
+}


### PR DESCRIPTION
Each time I provision the cluster, the kubeconfig file created locally does not contains user or context.
It seems to be copied from the cluster too early.

This PR waits for the source kubeconfig to be complete before the copy.