### PR TITLE
Fix creation of local kubeconfig file on MacOS

### DIFF
--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -19,7 +19,7 @@ data "external" "kubeconfig" {
         ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
               -l k8s -i ${local_file.ssh_private_key.filename} \
               ${oci_core_instance._[1].public_ip} \
-              sudo cat /etc/kubernetes/admin.conf | base64 -w0
+              'sudo cat /etc/kubernetes/admin.conf | base64 -w0'
             )'"}'
     EOT
   ]


### PR DESCRIPTION
While creating the resources using MacOS (with default ZSH shell) the local `kubeconfig` file is not being created properly.
Example:
```
apiVersion: v1
clusters:
- cluster:
    server: https://<external_ip>:6443
  name: kubernetes
contexts: null
current-context: ""
kind: Config
preferences: {}
users: null
```
In Linux (using BASH) the `kubeconfig` the file is being created properly.
Enclosing the command running on the remote machine in single quotes solves the problem.